### PR TITLE
Custom Headers in API Service Layer

### DIFF
--- a/react_data_sync/src/api/services/ApiService.ts
+++ b/react_data_sync/src/api/services/ApiService.ts
@@ -77,6 +77,11 @@ class ApiService {
     const response = await this.api.delete<T>(url, config);
     return response.data;
   }
+  
+  // Method to add custom headers to the axios request
+  export const getDataWithCustomHeaders = (endpoint: string, customHeaders: Record<string, string>) => {
+    return axios.get(`${config.API_BASE_URL}/${endpoint}`, { headers: { ...customHeaders } });
+  }
 
   // Method to add middleware to the ApiService instance
   use(middleware: (config: AxiosRequestConfig) => AxiosRequestConfig): void {


### PR DESCRIPTION
Allowed users to include custom headers in API requests, providing flexibility for scenarios that require additional authentication or customization.

